### PR TITLE
Fix: Update vercel.json to point to correct app.py path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,14 +2,14 @@
   "version": 2,
   "builds": [
     {
-      "src": "app.py",
+      "src": "ai-ops-interview/app.py",
       "use": "@vercel/python"
     }
   ],
   "rewrites": [
     {
       "source": "/(.*)",
-      "destination": "app.py"
+      "destination": "ai-ops-interview/app.py"
     }
   ]
 }


### PR DESCRIPTION
## 问题
Vercel 预览部署显示 **404 NOT_FOUND** 错误。

## 根本原因
`vercel.json` 配置中的路径错误：
- 配置指向 `app.py`（根目录）
- 但实际 `app.py` 位于 `ai-ops-interview/` 子目录中

Vercel 找不到 `app.py`，因此返回 404。

## 解决方案
更新 `vercel.json` 中的路径配置：
```json
{
  "builds": [
    {
      "src": "ai-ops-interview/app.py",  // 修复：正确路径
      "use": "@vercel/python"
    }
  ],
  "rewrites": [
    {
      "source": "/(.*)",
      "destination": "ai-ops-interview/app.py"  // 修复：正确路径
    }
  ]
}
```

## 文件结构
```
myResume/
├── ai-ops-interview/
│   ├── app.py          ← Flask 应用在这里
│   ├── templates/
│   ├── static/css/
│   └── content/
├── vercel.json         ← 需要指向 ai-ops-interview/app.py
├── README.md
└── requirements.txt
```

## 测试
合并后 Vercel 将自动重新部署，预览链接应该可以正常访问网站。