### PR TITLE
fix: 修复 CI 测试中 Python 模块导入问题

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Run tests with pytest
         working-directory: ./backend
         env:
+          PYTHONPATH: ${{ github.workspace }}/backend
           DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db
           SECRET_KEY: test-secret-key-for-ci
           DEBUG: true


### PR DESCRIPTION
## 🐛 问题描述

GitHub Actions CI/CD Pipeline 测试失败，所有 Python 版本（3.10/3.11/3.12）的测试都报错：

```
ModuleNotFoundError: No module named 'app' (from /home/runner/work/myResume/myResume/backend/tests/conftest.py)
ImportError while loading conftest '/home/runner/work/myResume/myResume/backend/tests/conftest.py'.
```

## 🔍 根本原因

在 CI 环境中运行 pytest 时，虽然在 `backend` 目录下执行，但 Python 不会自动将当前目录添加到 `sys.path`，导致 `conftest.py` 中的 `from app import create_app, db` 导入失败。

## ✅ 解决方案

在 `.github/workflows/ci.yml` 的 pytest 运行步骤中添加 `PYTHONPATH` 环境变量：

```yaml
env:
  PYTHONPATH: ${{ github.workspace }}/backend
  DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db
  SECRET_KEY: test-secret-key-for-ci
  DEBUG: true
```

## 📝 修改内容

- **文件**: `.github/workflows/ci.yml`
- **变更**: 在 "Run tests with pytest" 步骤中添加 `PYTHONPATH` 环境变量
- **影响**: 修复所有 Python 版本的测试运行

## 🧪 测试验证

修复后 CI 应该能够：
- ✅ 正常运行 pytest 测试
- ✅ 执行 flake8 代码检查
- ✅ 执行 mypy 类型检查
- ✅ 上传测试覆盖率报告
- ✅ 继续执行后续的 Docker 构建和 Vercel 部署

---

**Fixes**: CI/CD Pipeline 测试失败问题
**Related Issue**: 22677718253 workflow run failure