### PR TITLE
fix: 添加缺失的 flask-jwt-extended 依赖

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,7 @@ SQLAlchemy==2.0.23
 psycopg2-binary==2.9.9
 
 # 认证
+Flask-JWT-Extended==4.6.0
 PyJWT==2.8.0
 bcrypt==4.1.2
 


### PR DESCRIPTION
## 🐛 问题描述

CI/CD Pipeline 在修复了 PYTHONPATH 问题后，出现了**新的依赖缺失错误**：

```
ModuleNotFoundError: No module named 'flask_jwt_extended'
```

### 错误链路
```
tests/conftest.py:5: in <module>
    from app import create_app, db
app/__init__.py:7: in <module>
    from app.main import create_app
app/main.py:14: in <module>
    from flask_jwt_extended import JWTManager
E   ModuleNotFoundError: No module named 'flask_jwt_extended'
```

## 🔍 根本原因

代码中使用了 `Flask-JWT-Extended` 扩展（在 `app/main.py` 中导入），但 `requirements.txt` 中**没有声明这个依赖**。

### 使用位置
- `app/main.py:14` - `from flask_jwt_extended import JWTManager`
- 用于 JWT token 的管理和验证

## ✅ 解决方案

在 `backend/requirements.txt` 的认证部分添加缺失的依赖：

```txt
# 认证
Flask-JWT-Extended==4.6.0  # 👈 新增
PyJWT==2.8.0
bcrypt==4.1.2
```

## 📝 修改内容

- **文件**: `backend/requirements.txt`
- **变更**: 添加 `Flask-JWT-Extended==4.6.0`
- **影响**: 修复 CI 测试中的模块导入错误

## 🧪 测试验证

修复后 CI 应该能够：
- ✅ 成功导入 `flask_jwt_extended` 模块
- ✅ 正常运行所有测试
- ✅ 完成 Docker 构建和 Vercel 部署

---

**Related**: 修复 #38 合并后出现的新问题  
**Workflow Run**: 22766514198