### PR TITLE
fix: 修复测试数据库清理逻辑

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -23,6 +23,10 @@ def app():
 def database(app):
     """为每个测试创建干净的数据"""
     with app.app_context():
+        # 清理所有现有数据（SQLite 内存数据库）
+        db.session.query(User).delete()
+        db.session.commit()
+        
         # 开始事务
         db.session.begin_nested()
         yield db


### PR DESCRIPTION
## 🐛 问题描述

CI 测试出现数据库唯一约束冲突错误：

```
sqlite3.IntegrityError: UNIQUE constraint failed: users.username
[SQL: INSERT INTO users (username, email, password_hash, role, is_active, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)]
[parameters: ('testuser', 'test@example.com', ...)]
```

### 错误发生位置
- 测试：`tests/unit/test_permissions.py::TestAuthDecorators::test_require_auth_with_valid_token`
- Fixture：`auth_client`

---

## 🔍 根本原因

### 1. 测试使用 SQLite 内存数据库
虽然 CI 配置了 PostgreSQL 容器，但测试环境**故意使用 SQLite**（在 `app/config.py` 中配置）：
```python
class TestingConfig:
    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
```

### 2. 数据库清理逻辑不完善
`conftest.py` 中的 `database` fixture 试图用事务回滚来清理数据：
```python
@pytest.fixture(scope='function')
def database(app):
    with app.app_context():
        db.session.begin_nested()  # 开始嵌套事务
        yield db
        db.session.rollback()       # 回滚
```

**问题**：
- `auth_client` fixture 在创建用户时调用了 `database.session.commit()`
- 数据**已经提交**到 SQLite 内存数据库
- 当**第二个测试**使用 `auth_client` 时，尝试再次创建 `username='testuser'` 的用户
- SQLite 抛出**唯一约束冲突**错误

### 3. 错误链路
```
测试 1 使用 auth_client
  ↓
创建 testuser 并提交 ✅
  ↓
测试 1 完成，回滚（但已提交的数据还在）
  ↓
测试 2 使用 auth_client
  ↓
尝试再次创建 testuser ❌
  ↓
UNIQUE constraint failed: users.username
```

---

## ✅ 解决方案

在 `database` fixture 中，**每个测试开始前主动清理数据**：

```python
@pytest.fixture(scope='function')
def database(app):
    """为每个测试创建干净的数据"""
    with app.app_context():
        # 清理所有现有数据（SQLite 内存数据库）
        db.session.query(User).delete()
        db.session.commit()
        
        # 开始事务
        db.session.begin_nested()
        yield db
        # 回滚事务，清理数据
        db.session.rollback()
```

### 修改内容
- **文件**: `backend/tests/conftest.py`
- **变更**: 在 `database` fixture 中添加数据清理逻辑
- **效果**: 每个测试函数开始前，`users` 表会被清空

---

## 🧪 测试验证

修复后 CI 应该能够：
- ✅ 每个测试开始前数据库是干净的
- ✅ 多个测试使用 `auth_client` fixture 不会冲突
- ✅ 所有权限测试正常通过

---

**Related**: 继 #38 和 #39 后的第三个 CI 修复  
**Workflow Run**: 22766713276