### PR TITLE
feat: 使用宿主机网络模式部署 webhook server

### DIFF
--- a/webhook-deploy/README.md
+++ b/webhook-deploy/README.md
@@ -51,7 +51,7 @@ chmod +x deploy-webhook-v2.sh
 
 ```bash
 # 健康检查
-curl http://localhost:5001/health
+curl http://127.0.0.1:5001/health
 
 # 查看日志
 docker logs -f openhands-webhook-server
@@ -70,11 +70,11 @@ docker rm openhands-webhook-server 2>/dev/null || true
 sudo mkdir -p /app/logs
 sudo chmod 777 /app/logs
 
-# 3. 启动容器
+# 3. 启动容器（使用宿主机网络）
 docker run -d \
   --name openhands-webhook-server \
   --restart unless-stopped \
-  -p 5001:5001 \
+  --network host \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /app/logs:/app/logs \
   -v $(pwd)/webhook_server_v2.0.py:/app/webhook_server.py:ro \
@@ -84,7 +84,7 @@ docker run -d \
   python /app/webhook_server.py
 
 # 4. 验证
-curl http://localhost:5001/health
+curl http://127.0.0.1:5001/health
 ```
 
 ## 🧪 测试
@@ -108,7 +108,45 @@ curl -X POST "https://api.github.com/repos/YOUR_ORG/YOUR_REPO/issues" \
 docker logs -f openhands-webhook-server
 
 # 或 HTTP 接口
-curl http://localhost:5001/logs
+curl http://127.0.0.1:5001/logs
+```
+
+## 🌐 网络模式说明
+
+### 宿主机网络模式 (Host Network)
+
+本部署使用 **宿主机网络模式** (`--network host`)，优势包括：
+
+**优势**：
+- ✅ 无需端口映射，直接使用宿主机端口
+- ✅ 网络性能更好，无 NAT 开销
+- ✅ 简化网络配置，避免端口冲突
+- ✅ 容器可以直接访问宿主机网络接口
+
+**注意**：
+- ⚠️ 容器会占用宿主机的 5001 端口
+- ⚠️ 仅支持 Linux 系统（Windows/Mac 不支持）
+- ⚠️ 确保 5001 端口未被其他服务占用
+
+**防火墙配置**（如需要）：
+```bash
+# 允许 5001 端口访问
+sudo ufw allow 5001/tcp
+
+# 或限制特定 IP 访问
+sudo ufw allow from 140.82.112.0/20 to any port 5001 proto tcp
+```
+
+### 端口映射模式（可选）
+
+如果需要使用端口映射（例如在 Windows/Mac 上）：
+
+```bash
+docker run -d \
+  --name openhands-webhook-server \
+  --restart unless-stopped \
+  -p 5001:5001 \
+  ...
 ```
 
 ## 📝 配置 GitHub Workflow

--- a/webhook-deploy/deploy-webhook-v2.sh
+++ b/webhook-deploy/deploy-webhook-v2.sh
@@ -58,10 +58,11 @@ sudo chmod 777 /app/logs
 
 # 6. 启动新容器
 echo "🚀 启动新的 webhook 服务器..."
+echo "📡 使用宿主机网络模式 (host network)..."
 docker run -d \
     --name openhands-webhook-server \
     --restart unless-stopped \
-    -p 5001:5001 \
+    --network host \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /app/logs:/app/logs \
     -v "$WEBHOOK_CODE:/app/webhook_server.py:ro" \
@@ -76,16 +77,17 @@ sleep 5
 
 # 8. 健康检查
 echo "🏥 执行健康检查..."
-if curl -f http://localhost:5001/health; then
+if curl -f http://127.0.0.1:5001/health; then
     echo ""
     echo "✅ Webhook 服务器启动成功！"
     echo ""
     echo "======================================"
     echo "服务信息："
-    echo "  - 端口：5001"
-    echo "  - 健康检查：http://localhost:5001/health"
-    echo "  - 日志查看：http://localhost:5001/logs"
+    echo "  - 端口：5001 (宿主机网络)"
+    echo "  - 健康检查：http://127.0.0.1:5001/health"
+    echo "  - 日志查看：http://127.0.0.1:5001/logs"
     echo "  - 模式：Headless (无 UI)"
+    echo "  - 网络：宿主机网络模式 (host)"
     echo "  - 版本：v2.0"
     echo "======================================"
     echo ""


### PR DESCRIPTION
## 📦 PR 概述

将 Webhook Server 的 Docker 容器配置为使用**宿主机网络模式**，以提升网络性能并简化部署配置。

## ✨ 主要变更

### 1. 使用宿主机网络模式

**变更前**：
```bash
docker run -d \
  -p 5001:5001 \
  ...
```

**变更后**：
```bash
docker run -d \
  --network host \
  ...
```

### 2. 优势

- ✅ **更好的网络性能**：无 NAT 开销，直接使用宿主机网络栈
- ✅ **简化配置**：无需端口映射，避免端口冲突
- ✅ **直接访问**：容器可以直接访问宿主机网络接口
- ✅ **易于管理**：减少网络相关的配置问题

### 3. 文档更新

- ✅ 添加网络模式说明章节
- ✅ 说明宿主机网络模式的优势和注意事项
- ✅ 添加防火墙配置指南
- ✅ 提供端口映射模式作为可选方案

## 🔧 技术细节

### 宿主机网络模式 (`--network host`)

**适用场景**：
- Linux 服务器部署
- 需要最佳网络性能
- 简化网络配置

**注意事项**：
- ⚠️ 仅支持 Linux 系统（Windows/Mac 的 Docker Desktop 不支持）
- ⚠️ 容器会占用宿主机的 5001 端口
- ⚠️ 确保 5001 端口未被其他服务占用

### 防火墙配置

如需限制访问，可以配置防火墙：

```bash
# 允许 5001 端口访问
sudo ufw allow 5001/tcp

# 或限制特定 IP 访问（GitHub Actions IP 段）
sudo ufw allow from 140.82.112.0/20 to any port 5001 proto tcp
```

## 📁 文件变更

**修改的文件**：
- `webhook-deploy/deploy-webhook-v2.sh` - 添加 `--network host` 参数
- `webhook-deploy/README.md` - 更新部署说明和网络模式文档

## 🚀 部署方法

```bash
cd webhook-deploy
export WEBHOOK_SECRET="your-secret-here"
./deploy-webhook-v2.sh
```

部署后，服务将直接在宿主机的 5001 端口监听。

## 🧪 验证

```bash
# 健康检查
curl http://127.0.0.1:5001/health

# 查看日志
docker logs -f openhands-webhook-server
```

## 📊 对比

| 特性 | 端口映射模式 | 宿主机网络模式 |
|------|------------|--------------|
| **网络性能** | 有 NAT 开销 | ✅ 无开销 |
| **配置复杂度** | 需要映射端口 | ✅ 简单 |
| **端口冲突** | 可能冲突 | ✅ 可避免 |
| **跨平台** | ✅ 支持所有平台 | Linux only |
| **推荐场景** | 开发环境 | ✅ 生产环境 |

## ✅ 检查清单

- [x] 使用 `--network host` 参数
- [x] 更新部署脚本
- [x] 更新文档说明
- [x] 添加防火墙配置指南
- [x] 提供端口映射模式作为备选

## 🔗 参考文档

- [Docker 网络模式文档](https://docs.docker.com/network/host/)
- [OpenHands CLI 文档](https://docs.openhands.dev/openhands/usage/cli)

---

**相关 PR**: #43