### PR TITLE
feat: 添加 OpenHands JSON 解析详细调试日志

### DIFF
--- a/webhook-deploy/webhook_server_v2.0.py
+++ b/webhook-deploy/webhook_server_v2.0.py
@@ -231,19 +231,23 @@ def parse_openhands_json_output(output_file: str, issue_number: int) -> str:
     
     根据官方文档：https://docs.openhands.dev/sdk/arch/events
     JSONL 输出包含多种事件类型，需要正确处理
+    
+    调试模式：保留完整的原始 JSON 输出到日志
     """
     try:
         actions = []
         thoughts = []
         conversation = []
+        raw_events = []  # 保存所有原始事件用于调试
         
         with open(output_file, 'r', encoding='utf-8') as f:
-            for line in f:
+            for line_num, line in enumerate(f, 1):
                 line = line.strip()
-                # 跳过空行和装饰性文本
+                # 跳过空行
                 if not line:
                     continue
                 
+                # 跳过装饰性文本
                 skip_patterns = [
                     'OpenHands CLI', 'Initializing', 'Agent is', 
                     'Agent finished', '─', '✓', 'To override', 
@@ -256,8 +260,12 @@ def parse_openhands_json_output(output_file: str, issue_number: int) -> str:
                     # 解析 JSON
                     event = json.loads(line)
                     
-                    # 确保 event 是字典（某些行可能是字符串或其他类型）
+                    # 保存原始事件（前 500 字符）用于调试
+                    raw_events.append(f"Line {line_num}: {line[:500]}")
+                    
+                    # 确保 event 是字典
                     if not isinstance(event, dict):
+                        logger.debug(f"Issue #{issue_number} - Line {line_num}: 非字典类型 - {type(event)}")
                         continue
                     
                     kind = event.get('kind', '')
@@ -271,6 +279,8 @@ def parse_openhands_json_output(output_file: str, issue_number: int) -> str:
                         summary = event.get('summary', '') or ''
                         reasoning = event.get('reasoning_content', '') or ''
                         thought = event.get('thought', '') or ''
+                        
+                        logger.debug(f"Issue #{issue_number} - ActionEvent: tool={tool_name}, summary={summary[:50] if summary else 'None'}")
                         
                         # 构建工具调用信息
                         if tool_name:
@@ -292,6 +302,7 @@ def parse_openhands_json_output(output_file: str, issue_number: int) -> str:
                         
                         # 确保 llm_message 是字典
                         if not isinstance(llm_message, dict):
+                            logger.debug(f"Issue #{issue_number} - Line {line_num}: llm_message 非字典类型 - {type(llm_message)}")
                             continue
                         
                         content = llm_message.get('content', [])
@@ -305,6 +316,7 @@ def parse_openhands_json_output(output_file: str, issue_number: int) -> str:
                             
                             if text:
                                 emoji = "🤖" if source == 'agent' else "👤"
+                                logger.debug(f"Issue #{issue_number} - MessageEvent: source={source}, text={text[:50]}")
                                 conversation.append(f"{emoji} {text}")
                     
                     elif kind == 'ObservationEvent':
@@ -312,6 +324,7 @@ def parse_openhands_json_output(output_file: str, issue_number: int) -> str:
                         observation = event.get('observation', {})
                         
                         if not isinstance(observation, dict):
+                            logger.debug(f"Issue #{issue_number} - Line {line_num}: observation 非字典类型 - {type(observation)}")
                             continue
                         
                         content = observation.get('content', [])
@@ -321,6 +334,7 @@ def parse_openhands_json_output(output_file: str, issue_number: int) -> str:
                                 if isinstance(item, dict) and item.get('type') == 'text':
                                     obs = item.get('text', '')[:150]
                                     if obs:
+                                        logger.debug(f"Issue #{issue_number} - ObservationEvent: {obs[:50]}")
                                         actions.append(f"👁️ {obs}")
                                     break
                     
@@ -328,14 +342,23 @@ def parse_openhands_json_output(output_file: str, issue_number: int) -> str:
                         # AgentErrorEvent: Agent 错误
                         error_msg = event.get('message', '') or event.get('error', '')
                         if error_msg:
+                            logger.debug(f"Issue #{issue_number} - AgentErrorEvent: {error_msg[:100]}")
                             actions.append(f"❌ 错误：{error_msg[:150]}")
                     
-                except json.JSONDecodeError:
+                    else:
+                        # 其他事件类型
+                        if kind:
+                            logger.debug(f"Issue #{issue_number} - 未知事件类型：{kind}")
+                    
+                except json.JSONDecodeError as e:
                     # 非 JSON 行，跳过
+                    logger.debug(f"Issue #{issue_number} - Line {line_num}: JSON 解析失败 - {e}")
+                    logger.debug(f"Issue #{issue_number} - Line {line_num}: 原始内容 - {line[:200]}")
                     continue
                 except (AttributeError, TypeError, KeyError) as e:
                     # 数据结构不符合预期，跳过
-                    logger.debug(f"解析事件时出错：{e}")
+                    logger.debug(f"Issue #{issue_number} - Line {line_num}: 数据结构错误 - {e}")
+                    logger.debug(f"Issue #{issue_number} - Line {line_num}: 原始内容 - {line[:200]}")
                     continue
         
         # 构建摘要
@@ -362,13 +385,22 @@ def parse_openhands_json_output(output_file: str, issue_number: int) -> str:
                 summary_parts.append(f"  {i}. {msg}")
         
         if not summary_parts:
-            return "OpenHands 已执行完成（无详细输出）"
+            # 如果没有提取到内容，输出原始 JSON 的前几行用于调试
+            if raw_events:
+                logger.warning(f"Issue #{issue_number} - 未提取到有效事件，原始 JSON 前 5 行:")
+                for i, raw in enumerate(raw_events[:5], 1):
+                    logger.warning(f"  {i}. {raw}")
+                return f"OpenHands 已执行，解析到 {len(raw_events)} 个事件（但未识别类型）。请查看日志获取原始 JSON。"
+            else:
+                return "OpenHands 已执行完成（无详细输出）"
         
         # 使用 chr(10) 避免 f-string 语法错误
         return chr(10).join(summary_parts)
         
     except Exception as e:
-        logger.error(f"解析 JSON 输出失败：{e}")
+        logger.error(f"Issue #{issue_number} - 解析 JSON 输出失败：{e}")
+        import traceback
+        logger.error(f"Issue #{issue_number} - 堆栈跟踪：{traceback.format_exc()}")
         return f"OpenHands 已执行，但解析输出失败：{str(e)}"
 
 


### PR DESCRIPTION
## 🔍 问题背景

**现象**：OpenHands 执行成功，但没有看到详细的思考过程和行动结果

**日志显示**：
```
✅ OpenHands 处理成功 - Issue #56
执行摘要：OpenHands 已执行完成（无详细输出）
```

**根本原因**：
- OpenHands 的 JSONL 输出格式可能与预期不同
- JSON 解析函数没有提取到有效的事件数据
- 缺少调试日志，无法定位问题

## ✨ 解决方案

### 添加详细的调试日志

**修改的函数**：`parse_openhands_json_output()`

**新增功能**：

1. **保存原始 JSON 事件**
   ```python
   raw_events = []  # 保存所有原始事件用于调试
   raw_events.append(f"Line {line_num}: {line[:500]}")
   ```

2. **记录每个事件的解析过程**
   ```python
   # ActionEvent
   logger.debug(f"Issue #{issue_number} - ActionEvent: tool={tool_name}, summary={summary[:50]}")
   
   # MessageEvent
   logger.debug(f"Issue #{issue_number} - MessageEvent: source={source}, text={text[:50]}")
   
   # ObservationEvent
   logger.debug(f"Issue #{issue_number} - ObservationEvent: {obs[:50]}")
   ```

3. **记录所有错误和异常**
   ```python
   # JSON 解析失败
   logger.debug(f"Issue #{issue_number} - Line {line_num}: JSON 解析失败 - {e}")
   logger.debug(f"Issue #{issue_number} - Line {line_num}: 原始内容 - {line[:200]}")
   
   # 数据结构错误
   logger.debug(f"Issue #{issue_number} - Line {line_num}: 数据结构错误 - {e}")
   ```

4. **未识别事件时输出原始 JSON**
   ```python
   if not summary_parts and raw_events:
       logger.warning(f"Issue #{issue_number} - 未提取到有效事件，原始 JSON 前 5 行:")
       for i, raw in enumerate(raw_events[:5], 1):
           logger.warning(f"  {i}. {raw}")
   ```

5. **添加堆栈跟踪**
   ```python
   except Exception as e:
       logger.error(f"Issue #{issue_number} - 解析 JSON 输出失败：{e}")
       import traceback
       logger.error(f"Issue #{issue_number} - 堆栈跟踪：{traceback.format_exc()}")
   ```

## 📊 日志级别说明

### DEBUG 级别
- 正常解析过程
- 每个事件的类型和关键字段
- 工具调用、消息、观察结果

### WARNING 级别
- 未提取到有效事件时
- 输出原始 JSON 前 5 行

### ERROR 级别
- 解析失败时
- 包含完整的堆栈跟踪

## 🔧 部署后查看日志

### 方法 1: 查看完整日志
```bash
curl http://42.194.162.251:5001/logs | python3 -m json.tool | grep -A5 "Issue #56"
```

### 方法 2: 查看调试信息
```bash
# 需要启用 DEBUG 日志级别
# 修改 webhook_server_v2.0.py 的 logging.basicConfig(level=logging.DEBUG)
```

### 方法 3: SSH 查看原始 JSON 文件
```bash
ssh root@42.194.162.251
cat /tmp/tmp*.jsonl | head -50
```

## 📁 文件变更

**修改的文件**:
- `webhook-deploy/webhook_server_v2.0.py` (+39 行，-7 行)

**变更内容**:
1. 添加 `raw_events` 列表保存原始 JSON
2. 添加 `logger.debug` 记录解析过程
3. 添加 `logger.warning` 输出未识别事件
4. 添加 `logger.error` 输出堆栈跟踪
5. 改进错误处理和日志记录

## 🎯 预期效果

部署后，再次触发 Issue #56 或创建新的测试 Issue，将看到：

### 成功解析时
```
DEBUG: Issue #56 - ActionEvent: tool=file_editor, summary=view /root/project
DEBUG: Issue #56 - MessageEvent: source=agent, text=我已经查看了代码...
DEBUG: Issue #56 - ObservationEvent: 文件列表...
```

### 解析失败时
```
WARNING: Issue #56 - 未提取到有效事件，原始 JSON 前 5 行:
  1. Line 1: {"kind": "ActionEvent", "tool_name": "file_editor", ...}
  2. Line 2: {"kind": "MessageEvent", "source": "agent", ...}
  ...
```

### 异常时
```
ERROR: Issue #56 - 解析 JSON 输出失败：'str' object has no attribute 'get'
ERROR: Issue #56 - 堆栈跟踪：
Traceback (most recent call last):
  File "webhook_server_v2.0.py", line XXX, in parse_openhands_json_output
    ...
```

## ✅ 测试方法

### 1. 部署到服务器
```bash
ssh root@42.194.162.251
cd webhook-deploy
git pull origin add-debug-logs
pkill -f webhook_server
./deploy-host.sh
```

### 2. 创建测试 Issue
```bash
curl -X POST "https://api.github.com/repos/openhandsRoywnOrg/myResume/issues" \
  -H "Authorization: Bearer $GITHUB_TOKEN" \
  -d '{"title":"[测试] 调试日志验证","body":"请创建一个测试文件","labels":["ai-agent"]}'
```

### 3. 查看详细日志
```bash
curl http://42.194.162.251:5001/logs | python3 -c "
import sys, json
data = json.load(sys.stdin)
logs = data['logs']
for line in logs.split('\n'):
    if 'Issue #57' in line or 'DEBUG' in line or 'WARNING' in line:
        print(line)
"
```

## 🔗 相关 Issue

- Issue #56: [fix-me] 内容详情页布局优化 - 参照 Kubernetes 项目文档结构
- Issue #54: [测试] 验证 JSON 解析修复 - v2

---

**部署后请创建新的测试 Issue 验证调试日志！**